### PR TITLE
Add binary to the crate (#20)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,27 @@
 [package]
 name = "textplots"
 description = "Terminal plotting library."
-version = "0.5.4"
+version = "0.6.0"
 authors = ["Alexey Suslov <alexey.suslov@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/loony-bean/textplots-rs"
 keywords = ["plotting", "unicode", "charts"]
 categories = ["visualization"]
 readme = "README.md"
+edition = "2018"
+
+[lib]
+name = "textplots"
+path = "src/lib.rs"
+
+[[bin]]
+name = "textplots"
+path = "src/main.rs"
 
 [badges]
 travis-ci = { repository = "loony-bean/textplots-rs", branch = "master" }
 
 [dependencies]
 drawille = "0.2.3"
+clap = "2.33"
+meval = "0.2"

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ or another cool terminal plotting library.
 Contributions are very much welcome!
 
 ```rust
-extern crate textplots;
+#![feature(box_syntax)]
 
 use textplots::{Chart, Plot, Shape};
 
 fn main() {
     println!("y = sin(x) / x");
-    Chart::default().lineplot(&Shape::Continuous(|x| x.sin() / x)).display();
+    Chart::default().lineplot(&Shape::Continuous(box |x| x.sin() / x)).display();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,32 @@ or another cool terminal plotting library.
 
 Contributions are very much welcome!
 
-```rust
-#![feature(box_syntax)]
+# Usage
 
+```rust
 use textplots::{Chart, Plot, Shape};
 
 fn main() {
     println!("y = sin(x) / x");
-    Chart::default().lineplot(&Shape::Continuous(box |x| x.sin() / x)).display();
+    
+    Chart::default()
+        .lineplot(&Shape::Continuous(Box::new(|x| x.sin() / x)))
+        .display();
+}
+```
+
+With `box_syntax` feature:
+
+```rust
+#[feature(box_syntax)]
+use textplots::{Chart, Plot, Shape};
+
+fn main() {
+    println!("y = sin(x) / x");
+    
+    Chart::default()
+        .lineplot(&Shape::Continuous(box |x| x.sin() / x))
+        .display();
 }
 ```
 

--- a/examples/hist.rs
+++ b/examples/hist.rs
@@ -1,5 +1,3 @@
-extern crate textplots;
-
 use textplots::{utils, Chart, Plot, Shape};
 
 fn main() {

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use textplots::{Chart, Plot, Shape};
 
 fn main() {
@@ -7,8 +5,8 @@ fn main() {
     // https://github.com/loony-bean/textplots-rs/issues/8
     println!("y = -x^2; y = x^2");
     Chart::default()
-        .lineplot(&Shape::Continuous(box |x| (-x.powf(2.0))))
-        .lineplot(&Shape::Continuous(box |x| (x.powf(2.0))))
+        .lineplot(&Shape::Continuous(Box::new(|x| (-x.powf(2.0)))))
+        .lineplot(&Shape::Continuous(Box::new(|x| (x.powf(2.0)))))
         .display();
 
     // https://github.com/loony-bean/textplots-rs/issues/15

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -1,14 +1,14 @@
-extern crate textplots;
+#![feature(box_syntax)]
 
 use textplots::{Chart, Plot, Shape};
 
 fn main() {
-    // Display multiple plots
+    // Display multiple plots.
     // https://github.com/loony-bean/textplots-rs/issues/8
     println!("y = -x^2; y = x^2");
     Chart::default()
-        .lineplot(&Shape::Continuous(|x| (-x.powf(2.0))))
-        .lineplot(&Shape::Continuous(|x| (x.powf(2.0))))
+        .lineplot(&Shape::Continuous(box |x| (-x.powf(2.0))))
+        .lineplot(&Shape::Continuous(box |x| (x.powf(2.0))))
         .display();
 
     // https://github.com/loony-bean/textplots-rs/issues/15

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -1,32 +1,38 @@
-extern crate textplots;
+#![feature(box_syntax)]
 
 use textplots::{Chart, Plot, Shape};
 
 fn main() {
-    // You can pass any real value function
+    // You can pass any real value function.
     println!("y = atan(x)");
     Chart::default()
-        .lineplot(&Shape::Continuous(|x| x.atan()))
+        .lineplot(&Shape::Continuous(box |x| x.atan()))
         .display();
 
-    // The plot try to display everything that is a `normal` float, skipping NaN's and friends
+    // The same done with a stable Box syntax.
+    println!("y = atan(x)");
+    Chart::default()
+        .lineplot(&Shape::Continuous(Box::new(|x| x.atan())))
+        .display();
+
+    // The plot try to display everything that is a `normal` float, skipping NaN's and friends.
     println!("\ny = sin(x) / x");
     Chart::default()
-        .lineplot(&Shape::Continuous(|x| x.sin() / x))
+        .lineplot(&Shape::Continuous(box |x| x.sin() / x))
         .display();
 
     // Default viewport size is 120 x 60 points, with X values ranging from -10 to 10.
     println!("\ny = ln(x)");
     Chart::default()
-        .lineplot(&Shape::Continuous(f32::ln))
+        .lineplot(&Shape::Continuous(box f32::ln))
         .display();
 
     // You can plot several functions on the same chart.
     // However the resolution of text displays is low, and the result might not be great.
     println!("\ny = cos(x), y = sin(x) / 2");
     Chart::new(180, 60, -5.0, 5.0)
-        .lineplot(&Shape::Continuous(|x| x.cos()))
-        .lineplot(&Shape::Continuous(|x| x.sin() / 2.0))
+        .lineplot(&Shape::Continuous(box |x| x.cos()))
+        .lineplot(&Shape::Continuous(box |x| x.sin() / 2.0))
         .display();
 
     let points = [

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -1,15 +1,7 @@
-#![feature(box_syntax)]
-
 use textplots::{Chart, Plot, Shape};
 
 fn main() {
     // You can pass any real value function.
-    println!("y = atan(x)");
-    Chart::default()
-        .lineplot(&Shape::Continuous(box |x| x.atan()))
-        .display();
-
-    // The same done with a stable Box syntax.
     println!("y = atan(x)");
     Chart::default()
         .lineplot(&Shape::Continuous(Box::new(|x| x.atan())))
@@ -18,21 +10,21 @@ fn main() {
     // The plot try to display everything that is a `normal` float, skipping NaN's and friends.
     println!("\ny = sin(x) / x");
     Chart::default()
-        .lineplot(&Shape::Continuous(box |x| x.sin() / x))
+        .lineplot(&Shape::Continuous(Box::new(|x| x.sin() / x)))
         .display();
 
     // Default viewport size is 120 x 60 points, with X values ranging from -10 to 10.
     println!("\ny = ln(x)");
     Chart::default()
-        .lineplot(&Shape::Continuous(box f32::ln))
+        .lineplot(&Shape::Continuous(Box::new(f32::ln)))
         .display();
 
     // You can plot several functions on the same chart.
     // However the resolution of text displays is low, and the result might not be great.
     println!("\ny = cos(x), y = sin(x) / 2");
     Chart::new(180, 60, -5.0, 5.0)
-        .lineplot(&Shape::Continuous(box |x| x.cos()))
-        .lineplot(&Shape::Continuous(box |x| x.sin() / 2.0))
+        .lineplot(&Shape::Continuous(Box::new(|x| x.cos())))
+        .lineplot(&Shape::Continuous(Box::new(|x| x.sin() / 2.0)))
         .display();
 
     let points = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,17 +12,17 @@
 //! # Usage
 //! ```toml
 //! [dependencies]
-//! textplots = "0.5"
+//! textplots = "0.6"
 //! ```
 //!
 //! ```rust
-//! extern crate textplots;
+//! #![feature(box_syntax)]
 //!
 //! use textplots::{Chart, Plot, Shape};
 //!
 //! fn main() {
 //!     println!("y = sin(x) / x");
-//!     Chart::default().lineplot(&Shape::Continuous(|x| x.sin() / x)).display();
+//!     Chart::default().lineplot(&Shape::Continuous(box |x| x.sin() / x)).display();
 //! }
 //! ```
 //! It will display something like this:
@@ -33,12 +33,14 @@
 //! You can override the defaults calling `new`.
 //!
 //! ```rust
+//! #![feature(box_syntax)]
+//!
 //! use textplots::{Chart, Plot, Shape};
 //!
 //! println!("y = cos(x), y = sin(x) / 2");
 //! Chart::new(180, 60, -5.0, 5.0)
-//!     .lineplot(&Shape::Continuous(|x| x.cos()))
-//!     .lineplot(&Shape::Continuous(|x| x.sin() / 2.0))
+//!     .lineplot(&Shape::Continuous(box |x| x.cos()))
+//!     .lineplot(&Shape::Continuous(box |x| x.sin() / 2.0))
 //!     .display();
 //! ```
 //! <img src="https://github.com/loony-bean/textplots-rs/blob/master/doc/demo2.png?raw=true"/>
@@ -47,8 +49,6 @@
 //!
 //! <img src="https://github.com/loony-bean/textplots-rs/blob/master/doc/demo3.png?raw=true"/>
 //!
-
-extern crate drawille;
 
 pub mod scale;
 pub mod utils;
@@ -61,28 +61,28 @@ use std::f32;
 
 /// Controls the drawing.
 pub struct Chart<'a> {
-    /// Canvas width in points
+    /// Canvas width in points.
     width: u32,
-    /// Canvas height in points
+    /// Canvas height in points.
     height: u32,
-    /// X-axis start value
+    /// X-axis start value.
     xmin: f32,
-    /// X-axis end value
+    /// X-axis end value.
     xmax: f32,
-    /// Y-axis start value (calculated automatically to display all the domain values)
+    /// Y-axis start value (calculated automatically to display all the domain values).
     ymin: f32,
-    /// Y-axis end value (calculated automatically to display all the domain values)
+    /// Y-axis end value (calculated automatically to display all the domain values).
     ymax: f32,
-    /// Collection of shapes to be presented on the canvas
+    /// Collection of shapes to be presented on the canvas.
     shapes: Vec<&'a Shape<'a>>,
-    /// Underlying canvas object
+    /// Underlying canvas object.
     canvas: BrailleCanvas,
 }
 
 /// Specifies different kinds of plotted data.
 pub enum Shape<'a> {
-    /// Real value function
-    Continuous(fn(f32) -> f32),
+    /// Real value function.
+    Continuous(Box<dyn Fn(f32) -> f32 + 'a>),
     /// Points of a scatter plot.
     Points(&'a [(f32, f32)]),
     /// Points connected with lines.
@@ -196,7 +196,7 @@ impl<'a> Chart<'a> {
         self.display();
     }
 
-    /// Show axis
+    /// Show axis.
     pub fn axis(&mut self) {
         let x_scale = Scale::new(self.xmin..self.xmax, 0.0..self.width as f32);
         let y_scale = Scale::new(self.ymin..self.ymax, 0.0..self.height as f32);
@@ -209,7 +209,7 @@ impl<'a> Chart<'a> {
         }
     }
 
-    // Show figures
+    // Show figures.
     pub fn figures(&mut self) {
         for shape in &self.shapes {
             let x_scale = Scale::new(self.xmin..self.xmax, 0.0..self.width as f32);
@@ -282,7 +282,7 @@ impl<'a> Chart<'a> {
         }
     }
 
-    /// Return the frame
+    /// Return the frame.
     pub fn frame(&self) -> String {
         self.canvas.frame()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,15 +16,32 @@
 //! ```
 //!
 //! ```rust
-//! #![feature(box_syntax)]
-//!
 //! use textplots::{Chart, Plot, Shape};
 //!
 //! fn main() {
 //!     println!("y = sin(x) / x");
-//!     Chart::default().lineplot(&Shape::Continuous(box |x| x.sin() / x)).display();
+//!
+//!     Chart::default()
+//!     	.lineplot(&Shape::Continuous(Box::new(|x| x.sin() / x)))
+//!     	.display();
 //! }
 //! ```
+//!
+//! ...or with `box_syntax` feature...
+//!
+//! ```rust
+//! #![feature(box_syntax)]
+//! use textplots::{Chart, Plot, Shape};
+//!
+//! fn main() {
+//!     println!("y = sin(x) / x");
+//!
+//!     Chart::default()
+//!     	.lineplot(&Shape::Continuous(box |x| x.sin() / x))
+//!     	.display();
+//! }
+//! ```
+//!
 //! It will display something like this:
 //!
 //! <img src="https://github.com/loony-bean/textplots-rs/blob/master/doc/demo.png?raw=true"/>
@@ -33,22 +50,21 @@
 //! You can override the defaults calling `new`.
 //!
 //! ```rust
-//! #![feature(box_syntax)]
-//!
 //! use textplots::{Chart, Plot, Shape};
 //!
 //! println!("y = cos(x), y = sin(x) / 2");
+//!
 //! Chart::new(180, 60, -5.0, 5.0)
-//!     .lineplot(&Shape::Continuous(box |x| x.cos()))
-//!     .lineplot(&Shape::Continuous(box |x| x.sin() / 2.0))
+//!     .lineplot(&Shape::Continuous(Box::new(|x| x.cos())))
+//!     .lineplot(&Shape::Continuous(Box::new(|x| x.sin() / 2.0)))
 //!     .display();
 //! ```
+//!
 //! <img src="https://github.com/loony-bean/textplots-rs/blob/master/doc/demo2.png?raw=true"/>
 //!
 //! You could also plot series of points. See [Shape](enum.Shape.html) and [examples](https://github.com/loony-bean/textplots-rs/tree/master/examples) for more details.
 //!
 //! <img src="https://github.com/loony-bean/textplots-rs/blob/master/doc/demo3.png?raw=true"/>
-//!
 
 pub mod scale;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,8 @@
-#![feature(box_syntax)]
-
 use textplots::{Chart, Plot, Shape};
 use clap::{Arg, App};
 use std::process::exit;
 
 fn main() {
-    // automate with `env!()`?
     let matches = App::new(env!("CARGO_BIN_NAME"))
       .version(env!("CARGO_PKG_VERSION"))
       .author(env!("CARGO_PKG_AUTHORS"))
@@ -31,6 +28,6 @@ fn main() {
 
     println!("y = {}", formula);
     Chart::default()
-    	.lineplot(&Shape::Continuous(box |x| func(x.into()) as f32))
+    	.lineplot(&Shape::Continuous(Box::new(|x| func(x.into()) as f32)))
     	.display();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,36 @@
+#![feature(box_syntax)]
+
+use textplots::{Chart, Plot, Shape};
+use clap::{Arg, App};
+use std::process::exit;
+
+fn main() {
+    // automate with `env!()`?
+    let matches = App::new(env!("CARGO_BIN_NAME"))
+      .version(env!("CARGO_PKG_VERSION"))
+      .author(env!("CARGO_PKG_AUTHORS"))
+      .about(env!("CARGO_PKG_DESCRIPTION"))
+      .arg(Arg::with_name("FORMULA")
+           .help("Formula to plot")
+           .required(true)
+           .index(1))
+      .get_matches();
+
+    let formula = matches.value_of("FORMULA").unwrap(); // unreachable unwrap
+    let res = formula.parse().and_then(|expr: meval::Expr| expr.bind("x"));
+    let func = match res {
+        Ok(func) => func,
+        Err(err) => {
+            // if there was an error with parsing
+            // or binding "x", exit with error
+
+            eprintln!("{}", err);
+            exit(1);
+        },
+    };
+
+    println!("y = {}", formula);
+    Chart::default()
+    	.lineplot(&Shape::Continuous(box |x| func(x.into()) as f32))
+    	.display();
+}

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -11,7 +11,6 @@ pub struct Scale {
 impl Scale {
     /// Translates value from domain to range scale.
     /// ```
-    /// # extern crate textplots;
     /// # use textplots::scale::Scale;
     /// assert_eq!(-0.8, Scale::new(0_f32..10_f32, -1_f32..1_f32).linear(1.0));
     /// ```
@@ -23,7 +22,6 @@ impl Scale {
 
     /// Translates value from range to domain scale.
     /// ```
-    /// # extern crate textplots;
     /// # use textplots::scale::Scale;
     /// assert_eq!(5.5, Scale::new(0_f32..10_f32, -1_f32..1_f32).inv_linear(0.1));
     /// ```

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,6 @@
 /// falls into the specified interval is grouped into `bins` number of buckets of equal width.
 ///
 /// ```
-/// # extern crate textplots;
 /// # use textplots::utils::histogram;
 /// assert_eq!(vec![(0.0, 1.0), (5.0, 1.0)], histogram( &[ (0.0, 0.0), (9.0, 9.0), (10.0, 10.0) ], 0.0, 10.0, 2 ));
 /// ```


### PR DESCRIPTION
This PR adds a binary of the same name to the crate. It introduces a breaking change in the API. Resolves #21, resolves #20.


# Changes

* Add `src/main.rs`.
* Change `Shape::Continous` in `src/lib.rs`.

  Before:
  ```Rust
  pub enum Shape<'a> {
     Continuous(fn(f32) -> f32),
     ...
  }
  ```

  After:
  ```Rust
  pub enum Shape<'a> {
     Continuous(Box<dyn FnMut(f32) -> f32 + 'a>),
     ...
  }
  ```

  **This is a breaking change in the API, so [the minor version must be increased](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field).** I explained the motivation behind it in #21. I don't believe it is possible to add a dynamic math expression parser without introducing this change.

  I also added `#![feature(box_syntax)]` on top of every example and `box` before each closure, including the examples in documentation and `README.md`. If you do not wish to include this line each time you can switch to stable syntax: `Box::new(...)`. Alternative solutions are provided in #21.

  This change is incompatible with #14 (`no_std` support) as it requires allocating `Box`es. A possible solution is to use references or generic types in `Shape`. Another solution is to move drawing logic from `Chart` to shapes and introduce a `Shape` trait instead of an enum with predefined types in its fields.
* Change version in `Cargo.toml` to `0.6.0`.
* Set `edition = "2018"` in `Cargo.toml`. Add bin and lib sections to `Cargo.toml`.

  This makes configuring a separate binary and library easier. I also removed each `extern crate` since they are not necessary in the 2018 edition.
* Use [`clap`](https://github.com/clap-rs/clap) to parse args and display pretty info about the binary.
* Use [`meval`](https://github.com/rekka/meval-rs) to parse math expressions.


# Behavior

## Basic usage (prints the formula and displays the plot)

```
$ textplots 'e ^ (1 / x)'
```


## Error info on no formula

```
$ textplots
error: The following required arguments were not provided:
    <FORMULA>
    
USAGE:
    textplots <FORMULA>
        
For more information try --help
```


## `--help`

```
$ textplots --help
textplots 0.6.0
Alexey Suslov <alexey.suslov@gmail.com>
Terminal plotting library.

USAGE:
    textplots <FORMULA>
    
FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <FORMULA>    Formula to plot
```


## Error info on unknown variable

```
$ textplots 'y'
Evaluation error: unknown variable `y`.
```

## Error on unexpected token
```
$ textplots `100x`
Parse error: Unexpected token at byte 3.
```


# Possible future development

* Custom math parsing errors.
* Multiple plots.
* Colors (#10).
* Receiving input from pipes.