### PR TITLE
feat: Add the ability to plot in color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 travis-ci = { repository = "loony-bean/textplots-rs", branch = "master" }
 
 [dependencies]
-drawille = "0.2.3"
+drawille = "0.3.0"
 structopt = "0.3"
 meval = "0.2"
+rgb = "0.8.27"

--- a/examples/color.rs
+++ b/examples/color.rs
@@ -1,0 +1,113 @@
+use rgb::RGB8;
+use textplots::{Chart, ColorPlot, Shape};
+
+fn main() {
+    // You can plot several functions on the same chart.
+    // However the resolution of text displays is low, and the result might not be great.
+    println!("\ny = cos(x), y = sin(x) / 2");
+    Chart::new(180, 60, -5.0, 5.0)
+        .linecolorplot(
+            &Shape::Continuous(Box::new(|x| x.cos())),
+            RGB8 {
+                r: 255_u8,
+                g: 0,
+                b: 0,
+            },
+        )
+        .linecolorplot(
+            &Shape::Continuous(Box::new(|x| x.sin() / 2.0)),
+            RGB8 { r: 0, g: 0, b: 255 },
+        )
+        .display();
+
+    println!("\nRainbow");
+    let min_radius = 5.0;
+    let ring_gap = 0.5;
+    let segment_count = 20;
+    let num_rings = 6;
+
+    let mut rings = vec![];
+    for _ in 0..num_rings {
+        rings.push(vec![]);
+    }
+
+    for i in 0..segment_count {
+        let angle: f32 = ((std::f64::consts::PI as f32 / 2.0) / segment_count as f32) * i as f32;
+        let angle_sin = angle.sin() as f32;
+        let angle_cos = angle.cos() as f32;
+
+        for j in 0..num_rings {
+            rings[j].push((
+                (min_radius + (ring_gap * j as f32)) * angle_cos,
+                (min_radius + (ring_gap * j as f32)) * angle_sin,
+            ));
+        }
+    }
+
+    for i in 0..num_rings {
+        let mut ring_copy = rings[i].clone();
+        ring_copy.reverse();
+        for coord in ring_copy.iter_mut() {
+            coord.0 = 0.0 - coord.0;
+        }
+        rings[i].append(&mut ring_copy);
+    }
+
+    let max_radius = min_radius + ((num_rings as f32 + 1.0) * ring_gap);
+    Chart::new(180, 60, 0.0 - max_radius, max_radius)
+        .linecolorplot(
+            &Shape::Lines(rings[5].as_ref()),
+            RGB8 {
+                // Red
+                r: 255,
+                g: 0,
+                b: 0,
+            },
+        )
+        .linecolorplot(
+            &Shape::Lines(rings[4].as_ref()),
+            RGB8 {
+                // Orange
+                r: 255,
+                g: 165,
+                b: 0,
+            },
+        )
+        .linecolorplot(
+            &Shape::Lines(rings[3].as_ref()),
+            RGB8 {
+                // Yellow
+                r: 255,
+                g: 255,
+                b: 0,
+            },
+        )
+        .linecolorplot(
+            &Shape::Lines(rings[2].as_ref()),
+            RGB8 {
+                // Green
+                r: 0,
+                g: 255,
+                b: 0,
+            },
+        )
+        .linecolorplot(
+            &Shape::Lines(rings[1].as_ref()),
+            RGB8 {
+                // Blue
+                r: 0,
+                g: 0,
+                b: 255,
+            },
+        )
+        .linecolorplot(
+            &Shape::Lines(rings[0].as_ref()),
+            RGB8 {
+                // Violet
+                r: 136,
+                g: 43,
+                b: 226,
+            },
+        )
+        .display();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use structopt::StructOpt;
 use std::process::exit;
+use structopt::StructOpt;
 use textplots::{Chart, Plot, Shape};
 
 #[derive(StructOpt)]
@@ -24,7 +24,10 @@ struct Opt {
 fn main() {
     let opt = Opt::from_args();
 
-    let res = opt.formula.parse().and_then(|expr: meval::Expr| expr.bind("x"));
+    let res = opt
+        .formula
+        .parse()
+        .and_then(|expr: meval::Expr| expr.bind("x"));
     let func = match res {
         Ok(func) => func,
         Err(err) => {


### PR DESCRIPTION
This PR adds a new trait `ColorPlot` with a method `linecolorplot()` that can be used to add a shape to a canvas with a specified color. Currently color is defined by `drawille::PixelColor` which provides a set of sane default colors as well as the ability to specify RGB values. 

This is a non-breaking change. An example project has also been added to illustrate adding 2 different shapes to a canvas with 2 different colors. 

Refs: #10