### PR TITLE
feat: Add ability to get a raw string instead of printing to stdout

### DIFF
--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -47,4 +47,12 @@ fn main() {
 
     println!("\ny = scatter plot");
     Chart::default().lineplot(&Shape::Points(&points)).display();
+
+    // You can instead get the raw string value
+    println!("\nRender to string (and then print that string)");
+    let chart = Chart::default()
+        .lineplot(&Shape::Continuous(Box::new(|x| x.atan())))
+        .to_string();
+
+    println!("{}", chart);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,29 +174,27 @@ impl<'a> Chart<'a> {
         }
     }
 
-    /// Prints canvas content.
-    pub fn display(&mut self) {
+    pub fn to_string(&mut self) -> String {
         self.figures();
         self.axis();
 
-        let frame = self.canvas.frame();
-        let rows = frame.split('\n').count();
-        for (i, row) in frame.split('\n').enumerate() {
-            if i == 0 {
-                println!("{0} {1:.1}", row, self.ymax);
-            } else if i == (rows - 1) {
-                println!("{0} {1:.1}", row, self.ymin);
-            } else {
-                println!("{}", row);
-            }
+        let mut frame = self.canvas.frame();
+        if let Some(idx) = frame.find('\n') {
+            frame.insert_str(idx, &format!(" {0:.1}", self.ymax));
+            frame.push_str(&format!(
+                " {0:.1}\n{1: <width$.1}{2:.1}\n",
+                self.ymin,
+                self.xmin,
+                self.xmax,
+                width = (self.width as usize) / 2 - 3
+            ));
         }
+        frame
+    }
 
-        println!(
-            "{0: <width$.1}{1:.1}",
-            self.xmin,
-            self.xmax,
-            width = (self.width as usize) / 2 - 3
-        );
+    /// Prints canvas content.
+    pub fn display(&mut self) {
+        println!("{}", self.to_string());
     }
 
     /// Prints canvas content with some additional visual elements (like borders).


### PR DESCRIPTION
This PR adds a new method, `to_string()`, which will return an owned `String` of the rendered plot. This `String` can then be used with custom logging or reporting methods instead of just being piped to stdout. 

Instead of impl'ing the `From`/`Into` trait(s) a `to_string()` method was used which is more consistent with the std library's conversion to strings. 

Issue: https://github.com/loony-bean/textplots-rs/issues/29