### PR TITLE
Add axes formatting callbacks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,8 +253,8 @@ impl<'a> Chart<'a> {
     }
 
     pub fn to_string(&mut self) -> String {
-        self.figures();
         self.axis();
+        self.figures();
 
         let mut frame = self.canvas.frame();
         if let Some(idx) = frame.find('\n') {


### PR DESCRIPTION
This adds the ability to specify a callback for formatting the min/max labels for both the x and y axis. This allows formatting the x axis as dates (#9) or adding units, and including colored strings.

I have also included a commit that changes the rendering order so that the axes are printed behind the plots. This prevents the white of the axes resetting the color of the plots. If you want, I can split this up into multiple PRs.

Example Code (`from` and `to` are `chrono::NaiveDate`):

```rust
        let mut chart = Chart::new(200, 40, 0.0, (to - from).num_days() as f32)
            .xaxis_formatter(move |x| format!("{}", from.clone() + Duration::days(x as i64)))
            .yaxis_formatter(move |y| format!("{:.1} {}", y, unit.clone().white()));
```

Result (without reordering commit):

![](https://i.imgur.com/T7opee4.png)

Result (with reordering commit):

![](https://i.imgur.com/e7dN8dQ.png)