### PR TITLE
Split lib and bin dependencies; Fixed plot example;

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,21 @@ path = "src/lib.rs"
 [[bin]]
 name = "textplots"
 path = "src/main.rs"
+required-features = ["tool"]
 
 [badges]
 travis-ci = { repository = "loony-bean/textplots-rs", branch = "master" }
 
+[features]
+tool = [
+    "meval",
+    "structopt",
+]
+
 [dependencies]
 drawille = "0.3.0"
-structopt = "0.3"
-meval = "0.2"
+structopt = { version = "0.3", optional = true }
+meval = { version = "0.2", optional = true }
 rgb = "0.8.27"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -40,3 +40,17 @@ textplots '10*x + x^2 + 10*sin(x)*abs(x)' --xmin=-20 --xmax=20
 ## Bonus! Colored plots (see examples)
 
 <img src="https://raw.githubusercontent.com/loony-bean/textplots-rs/master/doc/demo5.png">
+
+# Building
+
+## Library
+
+```sh
+cargo build
+```
+
+## Binary
+
+```sh
+cargo build --bin --release textplots --features="tool"
+```

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -50,9 +50,15 @@ fn main() {
 
     // You can instead get the raw string value
     println!("\nRender to string (and then print that string)");
-    let chart = Chart::default()
-        .lineplot(&Shape::Continuous(Box::new(|x| x.atan())))
-        .to_string();
+    let mut chart = Chart::default();
+    let binding = Shape::Continuous(Box::new(|x| x.atan()));
+    let chart = chart.lineplot(&binding);
 
-    println!("{}", chart);
+    chart.axis();
+    chart.figures();
+
+    let chart_string = chart.to_string();
+
+    println!("{}", chart_string);
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,4 +67,5 @@ fn main() {
     chart
         .lineplot(&Shape::Continuous(Box::new(|x| func(x.into()) as f32)))
         .display();
+
 }


### PR DESCRIPTION
This pull request splits dependencies into two parts: the one for binary and the one for library.

This is accomplished by marking dependencies that are used for binary build as optional:

```
structopt = { version = "0.3", optional = true }
meval = { version = "0.2", optional = true }
```

These traits are enabled when using textplots with "tool" feature (read README.md for further information).

This pull request also fixes `plot` example, which was broken when `to_string()` implementation was moved do the implementation of the `Display` trait for the chart. 