### PR TITLE
Add ability to create y axis tick labels

### DIFF
--- a/examples/label.rs
+++ b/examples/label.rs
@@ -1,5 +1,7 @@
 use chrono::{Duration, NaiveDate};
-use textplots::{Chart, ColorPlot, LabelBuilder, LabelFormat, Shape};
+use textplots::{
+    Chart, ColorPlot, LabelBuilder, LabelFormat, Shape, TickDisplay, TickDisplayBuilder,
+};
 
 fn main() {
     // Specify how labels are displayed.
@@ -23,5 +25,6 @@ fn main() {
             format!("{}", start + Duration::days(val as i64))
         })))
         .y_label_format(LabelFormat::Value)
-        .display();
+        .y_tick_display(TickDisplay::Sparse)
+        .nice();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub struct Chart<'a> {
     /// Y-axis label format.
     y_label_format: LabelFormat,
     /// Y-axis tick label density
-    y_axis_tick_labels: YAxisTickLabels,
+    y_tick_labels: YAxisTickLabels,
 }
 
 /// Specifies different kinds of plotted data.
@@ -151,7 +151,7 @@ pub trait TickLabelBuilder<'a> {
     /// Specifies the tick label density of y-axis.
     /// YAxisTickLabels::Sparse will change the canvas height to the nearest multiple of 16
     /// YAxisTickLabels::Dense will change the canvas height to the nearest multiple of 8
-    fn y_tick_labels(&'a mut self, density: YAxisTickLabels) -> &'a mut Chart<'a>;
+    fn y_tick_display(&'a mut self, density: YAxisTickLabels) -> &'a mut Chart<'a>;
 }
 
 impl<'a> Default for Chart<'a> {
@@ -217,10 +217,10 @@ impl<'a> Display for Chart<'a> {
             frame.insert_str(idx, &format!(" {0}", self.format_y_axis_tick(self.ymax)));
 
             // Insert y-axis tick labels if requested
-            match self.y_axis_tick_labels {
+            match self.y_tick_labels {
                 YAxisTickLabels::None => {}
                 YAxisTickLabels::Sparse | YAxisTickLabels::Dense => {
-                    let row_spacing: u32 = self.y_axis_tick_labels.get_row_spacing();
+                    let row_spacing: u32 = self.y_tick_labels.get_row_spacing();
                     let num_steps: u32 = (self.height / 4) / row_spacing; // 4 pixels per row of text
                     let step_size = (self.ymax - self.ymin) / (num_steps) as f32;
                     for i in 1..(num_steps) {
@@ -278,7 +278,7 @@ impl<'a> Chart<'a> {
             y_style: LineStyle::Dotted,
             x_label_format: LabelFormat::Value,
             y_label_format: LabelFormat::Value,
-            y_axis_tick_labels: YAxisTickLabels::None,
+            y_tick_labels: YAxisTickLabels::None,
         }
     }
 
@@ -317,7 +317,7 @@ impl<'a> Chart<'a> {
             y_style: LineStyle::Dotted,
             x_label_format: LabelFormat::Value,
             y_label_format: LabelFormat::Value,
-            y_axis_tick_labels: YAxisTickLabels::None,
+            y_tick_labels: YAxisTickLabels::None,
         }
     }
 
@@ -653,11 +653,12 @@ impl<'a> LabelBuilder<'a> for Chart<'a> {
 
 impl<'a> TickLabelBuilder<'a> for Chart<'a> {
     /// Specifies the density of y-axis tick labels
-    fn y_tick_labels(&mut self, format: YAxisTickLabels) -> &mut Self {
-        // Round the height to the nearest multiple
+    fn y_tick_display(&mut self, format: YAxisTickLabels) -> &mut Self {
+        // Round the height to the nearest multiple using integer division
         match format {
             YAxisTickLabels::None => {}
             YAxisTickLabels::Sparse => {
+                // Round to the nearest 16
                 self.height = if self.height < 16 {
                     16
                 } else {
@@ -665,6 +666,7 @@ impl<'a> TickLabelBuilder<'a> for Chart<'a> {
                 }
             }
             YAxisTickLabels::Dense => {
+                // Round to the nearest 8
                 self.height = if self.height < 8 {
                     8
                 } else {
@@ -672,7 +674,7 @@ impl<'a> TickLabelBuilder<'a> for Chart<'a> {
                 }
             }
         }
-        self.y_axis_tick_labels = format;
+        self.y_tick_labels = format;
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,8 @@ pub struct Chart<'a> {
     x_label_format: LabelFormat,
     /// Y-axis label format.
     y_label_format: LabelFormat,
+    /// Y-axis tick label density
+    y_axis_tick_labels: YAxisTickLabels,
 }
 
 /// Specifies different kinds of plotted data.
@@ -143,6 +145,15 @@ pub trait LabelBuilder<'a> {
     fn y_label_format(&'a mut self, format: LabelFormat) -> &'a mut Chart<'a>;
 }
 
+/// Provides an interface for adding tick labels to the y-axis
+pub trait TickLabelBuilder<'a> {
+    // Horizontal labels don't allow for support of x-axis tick labels
+    /// Specifies the tick label density of y-axis.
+    /// YAxisTickLabels::Sparse will change the canvas height to the nearest multiple of 16
+    /// YAxisTickLabels::Dense will change the canvas height to the nearest multiple of 8
+    fn y_tick_labels(&'a mut self, density: YAxisTickLabels) -> &'a mut Chart<'a>;
+}
+
 impl<'a> Default for Chart<'a> {
     fn default() -> Self {
         Self::new(120, 60, -10.0, 10.0)
@@ -174,6 +185,26 @@ pub enum LabelFormat {
     Custom(Box<dyn Fn(f32) -> String>),
 }
 
+/// Specifies density of labels on the Y axis between ymin and ymax.
+/// Default value is `YAxisTickFormat::None`.
+pub enum YAxisTickLabels {
+    /// Tick labels are not displayed.
+    None,
+    /// Tick labels are sparsely shown (every 4th row)
+    Sparse,
+    /// Tick labels are densely shown (every 2nd row)
+    Dense,
+}
+impl YAxisTickLabels {
+    fn get_row_spacing(&self) -> u32 {
+        match self {
+            YAxisTickLabels::None => u32::MAX,
+            YAxisTickLabels::Sparse => 4,
+            YAxisTickLabels::Dense => 2,
+        }
+    }
+}
+
 impl<'a> Display for Chart<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         // get frame and replace space with U+2800 (BRAILLE PATTERN BLANK)
@@ -184,6 +215,27 @@ impl<'a> Display for Chart<'a> {
             let xmax = self.format_x_axis_tick(self.xmax);
 
             frame.insert_str(idx, &format!(" {0}", self.format_y_axis_tick(self.ymax)));
+
+            // Insert y-axis tick labels if requested
+            match self.y_axis_tick_labels {
+                YAxisTickLabels::None => {}
+                YAxisTickLabels::Sparse | YAxisTickLabels::Dense => {
+                    let row_spacing: u32 = self.y_axis_tick_labels.get_row_spacing();
+                    let num_steps: u32 = (self.height / 4) / row_spacing; // 4 pixels per row of text
+                    let step_size = (self.ymax - self.ymin) / (num_steps) as f32;
+                    for i in 1..(num_steps) {
+                        let matched_tuples: Vec<(usize, &str)> =
+                            frame.match_indices('\n').collect();
+                        frame.insert_str(
+                            matched_tuples[(i * row_spacing) as usize].0,
+                            &format!(
+                                " {0}",
+                                self.format_y_axis_tick(self.ymax - (step_size * i as f32))
+                            ),
+                        );
+                    }
+                }
+            }
 
             frame.push_str(&format!(
                 " {0}\n{1: <width$}{2}\n",
@@ -226,6 +278,7 @@ impl<'a> Chart<'a> {
             y_style: LineStyle::Dotted,
             x_label_format: LabelFormat::Value,
             y_label_format: LabelFormat::Value,
+            y_axis_tick_labels: YAxisTickLabels::None,
         }
     }
 
@@ -264,6 +317,7 @@ impl<'a> Chart<'a> {
             y_style: LineStyle::Dotted,
             x_label_format: LabelFormat::Value,
             y_label_format: LabelFormat::Value,
+            y_axis_tick_labels: YAxisTickLabels::None,
         }
     }
 
@@ -593,6 +647,31 @@ impl<'a> LabelBuilder<'a> for Chart<'a> {
     /// Specifies a formater for the y-axis label.
     fn y_label_format(&mut self, format: LabelFormat) -> &mut Self {
         self.y_label_format = format;
+        self
+    }
+}
+
+impl<'a> TickLabelBuilder<'a> for Chart<'a> {
+    /// Specifies the density of y-axis tick labels
+    fn y_tick_labels(&mut self, format: YAxisTickLabels) -> &mut Self {
+        match format {
+            YAxisTickLabels::None => {}
+            YAxisTickLabels::Sparse => {
+                self.height = if self.height < 16 {
+                    16
+                } else {
+                    self.height + 15 & !15
+                }
+            }
+            YAxisTickLabels::Dense => {
+                self.height = if self.height < 8 {
+                    8
+                } else {
+                    self.height + 7 & !7
+                }
+            }
+        }
+        self.y_axis_tick_labels = format;
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub struct Chart<'a> {
     /// Y-axis label format.
     y_label_format: LabelFormat,
     /// Y-axis tick label density
-    y_tick_labels: TickDisplay,
+    y_tick_display: TickDisplay,
 }
 
 /// Specifies different kinds of plotted data.
@@ -149,8 +149,8 @@ pub trait LabelBuilder<'a> {
 pub trait TickDisplayBuilder<'a> {
     // Horizontal labels don't allow for support of x-axis tick labels
     /// Specifies the tick label density of y-axis.
-    /// YAxisTickLabels::Sparse will change the canvas height to the nearest multiple of 16
-    /// YAxisTickLabels::Dense will change the canvas height to the nearest multiple of 8
+    /// TickDisplay::Sparse will change the canvas height to the nearest multiple of 16
+    /// TickDisplay::Dense will change the canvas height to the nearest multiple of 8
     fn y_tick_display(&'a mut self, density: TickDisplay) -> &'a mut Chart<'a>;
 }
 
@@ -198,7 +198,7 @@ pub enum TickDisplay {
 impl TickDisplay {
     fn get_row_spacing(&self) -> u32 {
         match self {
-            TickDisplay::None => u32::MAX,
+            TickDisplay::None => u32::MAX, // Unused
             TickDisplay::Sparse => 4,
             TickDisplay::Dense => 2,
         }
@@ -217,10 +217,10 @@ impl<'a> Display for Chart<'a> {
             frame.insert_str(idx, &format!(" {0}", self.format_y_axis_tick(self.ymax)));
 
             // Display y-axis ticks if requested
-            match self.y_tick_labels {
+            match self.y_tick_display {
                 TickDisplay::None => {}
                 TickDisplay::Sparse | TickDisplay::Dense => {
-                    let row_spacing: u32 = self.y_tick_labels.get_row_spacing(); // Rows between ticks
+                    let row_spacing: u32 = self.y_tick_display.get_row_spacing(); // Rows between ticks
                     let num_steps: u32 = (self.height / 4) / row_spacing; // 4 dots per row of text
                     let step_size = (self.ymax - self.ymin) / (num_steps) as f32;
                     for i in 1..(num_steps) {
@@ -282,7 +282,7 @@ impl<'a> Chart<'a> {
             y_style: LineStyle::Dotted,
             x_label_format: LabelFormat::Value,
             y_label_format: LabelFormat::Value,
-            y_tick_labels: TickDisplay::None,
+            y_tick_display: TickDisplay::None,
         }
     }
 
@@ -321,7 +321,7 @@ impl<'a> Chart<'a> {
             y_style: LineStyle::Dotted,
             x_label_format: LabelFormat::Value,
             y_label_format: LabelFormat::Value,
-            y_tick_labels: TickDisplay::None,
+            y_tick_display: TickDisplay::None,
         }
     }
 
@@ -657,9 +657,9 @@ impl<'a> LabelBuilder<'a> for Chart<'a> {
 
 impl<'a> TickDisplayBuilder<'a> for Chart<'a> {
     /// Specifies the density of y-axis tick labels
-    fn y_tick_display(&mut self, format: TickDisplay) -> &mut Self {
-        // Round the height to the nearest multiple using integer division
-        match format {
+    fn y_tick_display(&mut self, density: TickDisplay) -> &mut Self {
+        // Round the canvas height to the nearest multiple using integer division
+        match density {
             TickDisplay::None => {}
             TickDisplay::Sparse => {
                 // Round to the nearest 16
@@ -678,7 +678,7 @@ impl<'a> TickDisplayBuilder<'a> for Chart<'a> {
                 }
             }
         }
-        self.y_tick_labels = format;
+        self.y_tick_display = density;
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,20 +654,21 @@ impl<'a> LabelBuilder<'a> for Chart<'a> {
 impl<'a> TickLabelBuilder<'a> for Chart<'a> {
     /// Specifies the density of y-axis tick labels
     fn y_tick_labels(&mut self, format: YAxisTickLabels) -> &mut Self {
+        // Round the height to the nearest multiple
         match format {
             YAxisTickLabels::None => {}
             YAxisTickLabels::Sparse => {
                 self.height = if self.height < 16 {
                     16
                 } else {
-                    self.height + 15 & !15
+                    ((self.height + 8) / 16) * 16
                 }
             }
             YAxisTickLabels::Dense => {
                 self.height = if self.height < 8 {
                     8
                 } else {
-                    self.height + 7 & !7
+                    ((self.height + 4) / 8) * 8
                 }
             }
         }


### PR DESCRIPTION
This Pull Request uses the Builder Pattern modeled in [#47](https://github.com/loony-bean/textplots-rs/pull/47) to give the user the ability to add sparse or dense labeling of ticks along the y-axis. The same could not be done with the x-axis due to the text direction.

An example and plot are shown below:

```
Chart::new_with_y_range(200, 50, 0.0, 90 as f32, 0.0, 25_000.0)
        .linecolorplot(&Shape::Continuous(Box::new(|x| 1000.0 * (5.0 * (0.5 * x).sin() + 0.05 * x) + 9000.0)), rgb::RGB { r: 10, g: 100, b: 200 })
        .x_label_format(LabelFormat::Custom(Box::new(move |val| {format!("{}", chrono::Local::now().date_naive() + chrono::Duration::days(val as i64))})))
        .y_label_format(LabelFormat::Value)
        .y_tick_display(TickDisplay::Sparse)
        .nice();
```

![y-axis-tick-labels](https://github.com/loony-bean/textplots-rs/assets/78279314/932b256e-4697-434e-8683-7e999e85ed41)

A `TickDisplayBuilder` trait gives `Chart` a `y_tick_display()` method for the user to specify the use of tick labels on the y-axis. Calling this method also slightly alters the height of the frame to give better accuracy of positioning and spacing between the labels.

```
/// Specifies density of labels on the Y axis between ymin and ymax.
/// Default value is `TickDisplay::None`.
pub enum TickDisplay {
    /// Tick labels are not displayed.
    None,
    /// Tick labels are sparsely shown (every 4th row)
    Sparse,
    /// Tick labels are densely shown (every 2nd row)
    Dense,
}
```