### PR TITLE
expose Chart::borders as a public method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "textplots"
 description = "Terminal plotting library."
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Alexey Suslov <alexey.suslov@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/loony-bean/textplots-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,7 @@ impl<'a> Chart<'a> {
     }
 
     /// Displays bounding rect.
-    fn borders(&mut self) {
+    pub fn borders(&mut self) {
         let w = self.width;
         let h = self.height;
 


### PR DESCRIPTION
Hello, I don't see any reason to not expose this one. It is otherwise only accessible through the `nice` method; though the latter also automatically calls `display()`, which makes it unsuitable for holding onto a `String`. 

